### PR TITLE
Use Long_val, not Int_val, to extract int values.

### DIFF
--- a/lib/int128_conv.c
+++ b/lib/int128_conv.c
@@ -31,9 +31,9 @@ int128_of_int(value v)
 {
   CAMLparam1(v);
 #ifdef HAVE_INT128
-  CAMLreturn (copy_int128((__int128_t)Int_val(v)));
+  CAMLreturn (copy_int128((__int128_t)Long_val(v)));
 #else
-  int128 x = { .high = 0, .low = Int_val(v) };
+  int128 x = { .high = 0, .low = Long_val(v) };
   CAMLreturn(copy_int128(x));
 #endif
 }

--- a/lib/int16_conv.c
+++ b/lib/int16_conv.c
@@ -30,7 +30,7 @@ CAMLprim value
 int16_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int16((int16_t)Int_val(v)));
+  CAMLreturn (Val_int16((int16_t)Long_val(v)));
 }
 
 CAMLprim value

--- a/lib/int24_conv.c
+++ b/lib/int24_conv.c
@@ -30,7 +30,7 @@ CAMLprim value
 int24_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Long_val(v)) << 8));
 }
 
 CAMLprim value

--- a/lib/int32_conv.c
+++ b/lib/int32_conv.c
@@ -30,7 +30,7 @@ CAMLprim value
 int32_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (copy_int32((int32_t)Int_val(v)));
+  CAMLreturn (copy_int32((int32_t)Long_val(v)));
 }
 
 CAMLprim value

--- a/lib/int40_conv.c
+++ b/lib/int40_conv.c
@@ -30,7 +30,7 @@ CAMLprim value
 int40_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (copy_int64(((int64_t)Int_val(v)) << 24));
+  CAMLreturn (copy_int64(((int64_t)Long_val(v)) << 24));
 }
 
 CAMLprim value

--- a/lib/int48_conv.c
+++ b/lib/int48_conv.c
@@ -30,7 +30,7 @@ CAMLprim value
 int48_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (copy_int64(((int64_t)Int_val(v)) << 16));
+  CAMLreturn (copy_int64(((int64_t)Long_val(v)) << 16));
 }
 
 CAMLprim value

--- a/lib/int56_conv.c
+++ b/lib/int56_conv.c
@@ -30,7 +30,7 @@ CAMLprim value
 int56_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (copy_int64(((int64_t)Int_val(v)) << 8));
+  CAMLreturn (copy_int64(((int64_t)Long_val(v)) << 8));
 }
 
 CAMLprim value

--- a/lib/int64_conv.c
+++ b/lib/int64_conv.c
@@ -30,7 +30,7 @@ CAMLprim value
 int64_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (copy_int64((int64_t)Int_val(v)));
+  CAMLreturn (copy_int64((int64_t)Long_val(v)));
 }
 
 CAMLprim value

--- a/lib/int8_conv.c
+++ b/lib/int8_conv.c
@@ -32,7 +32,7 @@ CAMLprim value
 int8_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int8((int8_t)Int_val(v)));
+  CAMLreturn (Val_int8((int8_t)Long_val(v)));
 }
 
 CAMLprim value


### PR DESCRIPTION
`Int_val` truncates to a C `int`, but an OCaml `int` is often larger.

Before:

```ocaml
# Stdint.Int128.(to_int (of_int Pervasives.max_int));;
- : int = -1
# Stdint.Uint32.to_int (Stdint.Uint32.of_int 0xFFFFFFFF);;
- : int = -1
```

After:
```ocaml
# Stdint.Int128.(to_int (of_int Pervasives.max_int));;
- : int = 4611686018427387903
# Stdint.Uint32.to_int (Stdint.Uint32.of_int 0xFFFFFFFF);;
- : int = 4294967295
```

There's some [relevant discussion here](https://github.com/ocaml/ocaml/pull/1003#discussion_r96355502).

Not heavily tested.

Fixes #8.

