### PR TITLE
Fix opam syntax

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
-name: stdint
-version: 0.4.2
+name: "stdint"
+version: "0.4.2"
 maintainer: "Markus W. Weissmann <markus.weissmann@in.tum.de>"
 authors: [
   "Andre Nathan <andre@digirati.com.br>"


### PR DESCRIPTION
My opam was complaining about this when I `opam pin stdint`.