### PR TITLE
Speed up generic comparisons of int backed types

### DIFF
--- a/lib/stdint.mli
+++ b/lib/stdint.mli
@@ -1,12 +1,12 @@
 (** Standard integer types *)
 
-type int8
+type int8 = private int
 (** Signed 8-bit integer *)
 
-type int16
+type int16 = private int
 (** Signed 16-bit integer *)
 
-type int24
+type int24 = private int
 (** Signed 24-bit integer *)
 
 type int32 = Int32.t
@@ -27,13 +27,13 @@ type int64 = Int64.t
 type int128
 (** Signed 128-bit integer *)
 
-type uint8
+type uint8 = private int
 (** Unsigned 8-bit integer *)
 
-type uint16
+type uint16 = private int
 (** Unsigned 16-bit integer *)
 
-type uint24
+type uint24 = private int
 (** Unsigned 24-bit integer *)
 
 type uint32


### PR DESCRIPTION
By making the small ints type known to the compiler (via the "private"
keyword) it is able to generate much better code when comparing those
values.

Example:

  if v < Uint8.one then print_string "foo"

used to be compiled into (amd64 arch):

   73fe5:       48 8d 05 64 47 05 00    lea    0x54764(%rip),%rax        # c8750 <caml_lessthan>
   73fec:       e8 bf 6e 06 00          callq  daeb0 <caml_c_call>
   73ff1:       4c 8d 1d f0 95 0c 00    lea    0xc95f0(%rip),%r11        # 13d5e8 <caml_young_ptr>
   73ff8:       4d 8b 3b                mov    (%r11),%r15
   73ffb:       48 83 f8 01             cmp    $0x1,%rax
   73fff:       74 1a                   je     ...

whereas after that change the expensive call to C is avoided:

   73fd6:       48 8b 5b 10             mov    0x10(%rbx),%rbx
   73fda:       48 83 e3 55             and    $0x55,%rbx
   73fde:       48 8b 80 10 13 00 00    mov    0x1310(%rax),%rax
   73fe5:       48 39 c3                cmp    %rax,%rbx
   73fe8:       7d 1a                   jge    ...

Other consequences of using the private keyword:

- Stdint will only be compatible with OCaml compiler >= 3.11, which I
  think is OK;
- Users will be allowed to "cast" small ints values into int with the
  casting operator, yielding to weird values for signed types (since
  those are shifted), which I think is also acceptable.