### PR TITLE
Fix uint24 conversions to other int types

### DIFF
--- a/lib/uint24.h
+++ b/lib/uint24.h
@@ -1,8 +1,8 @@
 #ifndef OCAML_UINT24_H
 #define OCAML_UINT24_H
 
-#define Uint24_val(x) ((uint32_t)(((intnat)(x))))
-#define Val_uint24(x) (((intnat)((x) & 0xFFFFFF) << 1) + 1)
+#define Uint24_val(x) ((uint32_t)(Unsigned_long_val(x)))
+#define Val_uint24(x) (Val_long((x) & 0xFFFFFF))
 
 #endif
 


### PR DESCRIPTION
before:
```
  # Uint32.to_int (Uint24.(to_uint32 (of_int 42)));;
  - : int = 85
```
after:
```
  # Uint32.to_int (Uint24.(to_uint32 (of_int 42)));;
  - : int = 42
```
Closes #38