### PR TITLE
Fix conversion from any ints to uint24 and int24

### DIFF
--- a/lib/int24_conv.c
+++ b/lib/int24_conv.c
@@ -26,74 +26,80 @@
 #include "uint64.h"
 #include "uint128.h"
 
+#ifdef ARCH_SIXTYFOUR
+#  define SHFT 40
+#else
+# define SHFT 8
+#endif
+
 CAMLprim value
 int24_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Long_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Long_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_nativeint(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Nativeint_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Nativeint_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_float(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Double_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Double_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_int8(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int8_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Int8_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_int16(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int16_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Int16_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_int32(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int32_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Int32_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_int40(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int40_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Int40_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_int48(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int48_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Int48_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_int56(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int56_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Int56_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_int64(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int64_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Int64_val(v)) << SHFT));
 }
 
 CAMLprim value
@@ -101,7 +107,7 @@ int24_of_int128(value v)
 {
   CAMLparam1(v);
 #ifdef HAVE_INT128
-  CAMLreturn (Val_int24(((int32_t)Int128_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Int128_val(v)) << SHFT));
 #else
   failwith("unimplemented");
   CAMLreturn(Val_unit);
@@ -112,56 +118,56 @@ CAMLprim value
 int24_of_uint8(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint8_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint8_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_uint16(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint16_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint16_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_uint24(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint24_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint24_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_uint32(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint32_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint32_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_uint40(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint40_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint40_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_uint48(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint48_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint48_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_uint56(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint56_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint56_val(v)) << SHFT));
 }
 
 CAMLprim value
 int24_of_uint64(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint64_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint64_val(v)) << SHFT));
 }
 
 CAMLprim value
@@ -169,7 +175,7 @@ int24_of_uint128(value v)
 {
   CAMLparam1(v);
 #ifdef HAVE_UINT128
-  CAMLreturn (Val_int24(((int32_t)Uint128_val(v)) << 8));
+  CAMLreturn (Val_int24(((int32_t)Uint128_val(v)) << SHFT));
 #else
   failwith("unimplemented");
   CAMLreturn(Val_unit);

--- a/lib/uint24_conv.c
+++ b/lib/uint24_conv.c
@@ -30,77 +30,77 @@ CAMLprim value
 uint24_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Long_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Long_val(v))));
 }
 
 CAMLprim value
 uint24_of_nativeint(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Nativeint_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Nativeint_val(v))));
 }
 
 CAMLprim value
 uint24_of_float(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Double_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Double_val(v))));
 }
 
 CAMLprim value
 uint24_of_int8(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Int8_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int8_val(v))));
 }
 
 CAMLprim value
 uint24_of_int16(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Int16_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int16_val(v))));
 }
 
 CAMLprim value
 uint24_of_int24(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Int24_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int24_val(v))));
 }
 
 CAMLprim value
 uint24_of_int32(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Int32_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int32_val(v))));
 }
 
 CAMLprim value
 uint24_of_int40(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Int40_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int40_val(v))));
 }
 
 CAMLprim value
 uint24_of_int48(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Int48_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int48_val(v))));
 }
 
 CAMLprim value
 uint24_of_int56(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Int56_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int56_val(v))));
 }
 
 CAMLprim value
 uint24_of_int64(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Int64_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int64_val(v))));
 }
 
 CAMLprim value
@@ -108,7 +108,7 @@ uint24_of_int128(value v)
 {
   CAMLparam1(v);
 #ifdef HAVE_INT128
-  CAMLreturn (Val_uint24(((uint32_t)Int128_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Int128_val(v))));
 #else
   failwith("unimplemented");
   CAMLreturn(Val_unit);
@@ -119,49 +119,49 @@ CAMLprim value
 uint24_of_uint8(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Uint8_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Uint8_val(v))));
 }
 
 CAMLprim value
 uint24_of_uint16(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Uint16_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Uint16_val(v))));
 }
 
 CAMLprim value
 uint24_of_uint32(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Uint32_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Uint32_val(v))));
 }
 
 CAMLprim value
 uint24_of_uint40(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Uint40_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Uint40_val(v))));
 }
 
 CAMLprim value
 uint24_of_uint48(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Uint48_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Uint48_val(v))));
 }
 
 CAMLprim value
 uint24_of_uint56(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Uint56_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Uint56_val(v))));
 }
 
 CAMLprim value
 uint24_of_uint64(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_uint24(((uint32_t)Uint64_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Uint64_val(v))));
 }
 
 CAMLprim value
@@ -169,7 +169,7 @@ uint24_of_uint128(value v)
 {
   CAMLparam1(v);
 #ifdef HAVE_UINT128
-  CAMLreturn (Val_uint24(((uint32_t)Uint128_val(v)) << 8));
+  CAMLreturn (Val_uint24(((uint32_t)Uint128_val(v))));
 #else
   failwith("unimplemented");
   CAMLreturn(Val_unit);


### PR DESCRIPTION
int24 was wrong on 64bits arch only, whereas uint24 was wrong for all
archs.

NOTICE: this fix assumes that the previous fix re. uint24 is merged already. Otherwise, conversion to uint24 are still bogus (although less so).

Before:
```
  # Uint24.(of_uint32 (Uint32.of_int 42) |> to_int);;
  - : int = 10752
  # Int24.(of_int32 (Int32.of_int 42) |> to_int);;
  - : int = 10752
```
After:
```
  # Uint24.(of_uint32 (Uint32.of_int 42) |> to_int);;
  - : int = 42
  # Uint24.(of_uint32 (Uint32.of_int 42) |> to_int);;
  - : int = 42
```
Closes #40

(cherry picked from commit 142ce47908c4bbfcbeef748cfa58778510c05338)