### PR TITLE
Fix int24 failing to recover from casts.

### DIFF
--- a/lib/int24_conv.c
+++ b/lib/int24_conv.c
@@ -26,80 +26,74 @@
 #include "uint64.h"
 #include "uint128.h"
 
-#ifdef ARCH_SIXTYFOUR
-#  define SHFT 40
-#else
-# define SHFT 8
-#endif
-
 CAMLprim value
 int24_of_int(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Long_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Long_val(v)));
 }
 
 CAMLprim value
 int24_of_nativeint(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Nativeint_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Nativeint_val(v)));
 }
 
 CAMLprim value
 int24_of_float(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Double_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Double_val(v)));
 }
 
 CAMLprim value
 int24_of_int8(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int8_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Int8_val(v)));
 }
 
 CAMLprim value
 int24_of_int16(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int16_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Int16_val(v)));
 }
 
 CAMLprim value
 int24_of_int32(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int32_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Int32_val(v)));
 }
 
 CAMLprim value
 int24_of_int40(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int40_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Int40_val(v)));
 }
 
 CAMLprim value
 int24_of_int48(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int48_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Int48_val(v)));
 }
 
 CAMLprim value
 int24_of_int56(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int56_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Int56_val(v)));
 }
 
 CAMLprim value
 int24_of_int64(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Int64_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Int64_val(v)));
 }
 
 CAMLprim value
@@ -107,7 +101,7 @@ int24_of_int128(value v)
 {
   CAMLparam1(v);
 #ifdef HAVE_INT128
-  CAMLreturn (Val_int24(((int32_t)Int128_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Int128_val(v)));
 #else
   failwith("unimplemented");
   CAMLreturn(Val_unit);
@@ -118,56 +112,56 @@ CAMLprim value
 int24_of_uint8(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint8_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint8_val(v)));
 }
 
 CAMLprim value
 int24_of_uint16(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint16_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint16_val(v)));
 }
 
 CAMLprim value
 int24_of_uint24(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint24_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint24_val(v)));
 }
 
 CAMLprim value
 int24_of_uint32(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint32_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint32_val(v)));
 }
 
 CAMLprim value
 int24_of_uint40(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint40_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint40_val(v)));
 }
 
 CAMLprim value
 int24_of_uint48(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint48_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint48_val(v)));
 }
 
 CAMLprim value
 int24_of_uint56(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint56_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint56_val(v)));
 }
 
 CAMLprim value
 int24_of_uint64(value v)
 {
   CAMLparam1(v);
-  CAMLreturn (Val_int24(((int32_t)Uint64_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint64_val(v)));
 }
 
 CAMLprim value
@@ -175,7 +169,7 @@ int24_of_uint128(value v)
 {
   CAMLparam1(v);
 #ifdef HAVE_UINT128
-  CAMLreturn (Val_int24(((int32_t)Uint128_val(v)) << SHFT));
+  CAMLreturn (Val_int24((int32_t)Uint128_val(v)));
 #else
   failwith("unimplemented");
   CAMLreturn(Val_unit);


### PR DESCRIPTION
There were actually relevant warnings from the C compiler, hidden by
default.

Before:

```
  # Uint32.(of_int (-5) |> to_int24) |> Int24.to_int;;
  - : int = 0
```

After:

```
  # Uint32.(of_int (-5) |> to_int24) |> Int24.to_int;;
  - : int = -5
```

Closes #42