### PR TITLE
Fix various bugs in signed integers related to sign-extension

### DIFF
--- a/lib/int40_stubs.c
+++ b/lib/int40_stubs.c
@@ -13,6 +13,13 @@
 static const int64_t mask = 0xFFFFFFFFFF000000LL;
 
 CAMLprim value
+int40_mul(value v1, value v2)
+{
+  CAMLparam2(v1, v2);
+  CAMLreturn (copy_int40(Int40_val(v1) * Int64_val(v2)));
+}
+
+CAMLprim value
 int40_div(value v1, value v2)
 {
   CAMLparam2(v1, v2);

--- a/lib/int48_stubs.c
+++ b/lib/int48_stubs.c
@@ -13,6 +13,13 @@
 static const int64_t mask = 0xFFFFFFFFFFFF0000LL;
 
 CAMLprim value
+int48_mul(value v1, value v2)
+{
+  CAMLparam2(v1, v2);
+  CAMLreturn (copy_int48(Int48_val(v1) * Int64_val(v2)));
+}
+
+CAMLprim value
 int48_div(value v1, value v2)
 {
   CAMLparam2(v1, v2);

--- a/lib/int56_stubs.c
+++ b/lib/int56_stubs.c
@@ -13,6 +13,13 @@
 static const int64_t mask = 0xFFFFFFFFFFFFFF00LL;
 
 CAMLprim value
+int56_mul(value v1, value v2)
+{
+  CAMLparam2(v1, v2);
+  CAMLreturn (copy_int56(Int56_val(v1) * Int64_val(v2)));
+}
+
+CAMLprim value
 int56_div(value v1, value v2)
 {
   CAMLparam2(v1, v2);

--- a/lib/stdint.ml
+++ b/lib/stdint.ml
@@ -432,7 +432,7 @@ module Int40 = struct
     let fmt = "ll"
     let name = "Int40"
 
-    external mul : int40 -> int40 -> int40 = "uint40_mul"
+    external mul : int40 -> int40 -> int40 = "int40_mul"
     external div : int40 -> int40 -> int40 = "int40_div"
     external logxor : int40 -> int40 -> int40 = "uint40_xor"
     external shift_right : int40 -> int -> int40 = "uint40_shift_right"
@@ -516,7 +516,7 @@ module Int48 = struct
     let fmt = "ll"
     let name = "Int48"
 
-    external mul : int48 -> int48 -> int48 = "uint48_mul"
+    external mul : int48 -> int48 -> int48 = "int48_mul"
     external div : int48 -> int48 -> int48 = "int48_div"
     external logxor : int48 -> int48 -> int48 = "uint48_xor"
     external shift_right : int48 -> int -> int48 = "uint48_shift_right"
@@ -600,7 +600,7 @@ module Int56 = struct
     let fmt = "ll"
     let name = "Int56"
 
-    external mul : int56 -> int56 -> int56 = "uint56_mul"
+    external mul : int56 -> int56 -> int56 = "int56_mul"
     external div : int56 -> int56 -> int56 = "int56_div"
     external logxor : int56 -> int56 -> int56 = "uint56_xor"
     external shift_right : int56 -> int -> int56 = "uint56_shift_right"

--- a/lib/stdint.ml
+++ b/lib/stdint.ml
@@ -435,8 +435,8 @@ module Int40 = struct
     external mul : int40 -> int40 -> int40 = "int40_mul"
     external div : int40 -> int40 -> int40 = "int40_div"
     external logxor : int40 -> int40 -> int40 = "uint40_xor"
-    external shift_right : int40 -> int -> int40 = "uint40_shift_right"
-    external shift_right_logical : int40 -> int -> int40 = "int40_shift_right"
+    external shift_right : int40 -> int -> int40 = "int40_shift_right"
+    external shift_right_logical : int40 -> int -> int40 = "uint40_shift_right"
 
     external of_int       :       int ->     int40 = "int40_of_int"
     external of_nativeint : nativeint ->     int40 = "int40_of_nativeint"
@@ -519,8 +519,8 @@ module Int48 = struct
     external mul : int48 -> int48 -> int48 = "int48_mul"
     external div : int48 -> int48 -> int48 = "int48_div"
     external logxor : int48 -> int48 -> int48 = "uint48_xor"
-    external shift_right : int48 -> int -> int48 = "uint48_shift_right"
-    external shift_right_logical : int48 -> int -> int48 = "int48_shift_right"
+    external shift_right : int48 -> int -> int48 = "int48_shift_right"
+    external shift_right_logical : int48 -> int -> int48 = "uint48_shift_right"
 
     external of_int       :       int ->     int48 = "int48_of_int"
     external of_nativeint : nativeint ->     int48 = "int48_of_nativeint"
@@ -603,8 +603,8 @@ module Int56 = struct
     external mul : int56 -> int56 -> int56 = "int56_mul"
     external div : int56 -> int56 -> int56 = "int56_div"
     external logxor : int56 -> int56 -> int56 = "uint56_xor"
-    external shift_right : int56 -> int -> int56 = "uint56_shift_right"
-    external shift_right_logical : int56 -> int -> int56 = "int56_shift_right"
+    external shift_right : int56 -> int -> int56 = "int56_shift_right"
+    external shift_right_logical : int56 -> int -> int56 = "uint56_shift_right"
 
     external of_int       :       int ->     int56 = "int56_of_int"
     external of_nativeint : nativeint ->     int56 = "int56_of_nativeint"

--- a/tests/stdint_test.ml
+++ b/tests/stdint_test.ml
@@ -31,6 +31,8 @@ module Tester (I : Stdint.Int) : TESTER =
 struct
   include IntBounds (I)
 
+  let ( *** ) = ( * )  (* Preserve int mul for later use *)
+
   open I
 
   let tests = [
@@ -65,6 +67,16 @@ struct
     test "An integer should perform right-shifts correctly"
       QCheck.(pair in_range (int_bound 31)) (fun (x, y) ->
         shift_right (of_int x) y = of_int (x asr y)) ;
+
+    test "Arithmetic shifts must sign-extend"
+      QCheck.(int_range 0 200) (fun i ->
+        let v = shift_right min_int i in
+        (compare min_int zero) *** (compare v zero) >= 0) ;
+
+    test "Logical shifts must not sign-extend"
+      QCheck.(int_range 0 200) (fun i ->
+        let v = shift_right_logical min_int i in
+        compare v zero >= 0) ;
 
     test "An integer should perform float conversions correctly"
       in_range_float (fun x ->

--- a/tests/stdint_test.ml
+++ b/tests/stdint_test.ml
@@ -45,19 +45,19 @@ struct
     test "An integer should not modify strings when converted"
       in_range (fun x -> to_string (of_int x) = string_of_int x) ;
 
-    test "An integer should perform logical and correctly"
+    test "An integer should perform logical-and correctly"
       (QCheck.pair pos_int pos_int) (fun (x, y) ->
         to_int (logand (of_int x) (of_int y)) = x land y) ;
 
-    test "An integer should perform logical or correctly"
+    test "An integer should perform logical-or correctly"
       (QCheck.pair pos_int pos_int) (fun (x, y) ->
         to_int (logor (of_int x) (of_int y)) = x lor y) ;
 
-    test "An integer should perform logical xor correctly"
+    test "An integer should perform logical-xor correctly"
       (QCheck.pair pos_int pos_int) (fun (x, y) ->
         to_int (logxor (of_int x) (of_int y)) = x lxor y) ;
 
-    test "An integer should perform logical not correctly"
+    test "An integer should perform logical-not correctly"
       pos_int (fun x -> lognot (of_int x) = of_int (lnot x)) ;
 
     test "An integer should perform left-shifts correctly"


### PR DESCRIPTION
Namely, `mul` was losing the sign and right shifts were inverted.
See accompanying tests.