### PR TITLE
Ensure there's a 16-byte aligned 128-bit int in the heap

### DIFF
--- a/lib/int128.h
+++ b/lib/int128.h
@@ -2,13 +2,18 @@
 #define OCAML_INT128_H
 
 #if defined(__SIZEOF_INT128__) 
+
 #define HAVE_INT128
 typedef __int128_t int128;
+#define Int128_val(v) (*((__int128_t *)((intnat *)Data_custom_val(v) + (3 & (0 - ((uintptr_t)Data_custom_val(v) & 0x8) >> 3)))))
+
 #else
+
 typedef struct { int64_t high; uint64_t low; } int128;
-#endif
 
 #define Int128_val(v) (*((int128 *)Data_custom_val(v)))
+
+#endif
 
 CAMLextern value copy_int128(int128 i);
 

--- a/lib/int128_stubs.c
+++ b/lib/int128_stubs.c
@@ -138,6 +138,26 @@ struct custom_operations int128_ops = {
   int128_deserialize
 };
 
+#ifdef HAVE_INT128
+CAMLprim value
+copy_int128(__int128_t i)
+{
+  CAMLparam0();
+  value res = caml_alloc_custom(&int128_ops, 40, 0, 1);
+  uint64_t *v = (uint64_t *)Data_custom_val(res);
+  /* Write both an aligned and unaligned version */
+  if ((uintptr_t)v & 0x8) {
+    *(int64_t *)v = (uint64_t)i;
+    v[1] = (int64_t)(i >> 64);
+    *(__int128_t *)(v + 3) = i;
+  } else {
+    *(__int128_t *)v = i;
+    *(int64_t *)(v + 3) = (uint64_t)i;
+    v[4] = (int64_t)(i >> 64);
+  }
+  CAMLreturn (res);
+}
+#else
 CAMLprim value
 copy_int128(int128 i)
 {
@@ -146,6 +166,7 @@ copy_int128(int128 i)
   Int128_val(res) = i;
   CAMLreturn (res);
 }
+#endif
 
 CAMLprim value
 int128_add(value v1, value v2)

--- a/lib/uint128.h
+++ b/lib/uint128.h
@@ -2,13 +2,18 @@
 #define OCAML_UINT128_H
 
 #if defined(__SIZEOF_INT128__) 
+
 #define HAVE_UINT128
 typedef __uint128_t uint128;
+#define Uint128_val(v) (*((__uint128_t *)((uintnat *)Data_custom_val(v) + (3 & (0 - ((uintptr_t)Data_custom_val(v) & 0x8) >> 3)))))
+
 #else
+
 typedef struct { uint64_t high; uint64_t low; } uint128;
-#endif
 
 #define Uint128_val(v) (*((uint128 *)Data_custom_val(v)))
+
+#endif
 
 CAMLextern value copy_uint128(uint128 i);
 CAMLextern value suint128_add(value v1, value v2, CAMLprim value (*)(uint128));
@@ -20,4 +25,3 @@ CAMLextern value suint128_xor(value v1, value v2, CAMLprim value (*)(uint128));
 CAMLextern value suint128_shift_left(value v1, value v2, CAMLprim value (*)(uint128));
 
 #endif
-

--- a/lib/uint128_stubs.c
+++ b/lib/uint128_stubs.c
@@ -180,6 +180,26 @@ struct custom_operations uint128_ops = {
   uint128_deserialize
 };
 
+#ifdef HAVE_UINT128
+CAMLprim value
+copy_uint128(__uint128_t i)
+{
+  CAMLparam0();
+  value res = caml_alloc_custom(&uint128_ops, 40, 0, 1);
+  uint64_t *v = (uint64_t *)Data_custom_val(res);
+  /* Write both an aligned and unaligned version */
+  if ((uintptr_t)v & 0x8) {
+    v[0] = (uint64_t)i;
+    v[1] = (uint64_t)(i >> 64);
+    *(__uint128_t *)(v + 3) = i;
+  } else {
+    *(__uint128_t *)v = i;
+    v[3] = (uint64_t)i;
+    v[4] = (uint64_t)(i >> 64);
+  }
+  CAMLreturn (res);
+}
+#else
 CAMLprim value
 copy_uint128(uint128 i)
 {
@@ -188,6 +208,7 @@ copy_uint128(uint128 i)
   Uint128_val(res) = i;
   CAMLreturn (res);
 }
+#endif
 
 CAMLprim value
 suint128_add(value v1, value v2, CAMLprim value (*copy)(uint128))


### PR DESCRIPTION
This sprang from the unexpected discovery in a library that `Stdint.Uint32.max_int` was `-1`! This PR consists of 3 sort of related pieces of work:

- `Long_val` does not return `long` - it returns `intnat`. OCaml uses `long` to mean 64-bits (defined in its headers) but C does not. `Uint32.max_int` now returns `0xFFFFFFFF` (and other fixes)
- Windows with GCC 9.2 reveals alignment problems with 128-bit numbers which manifests itself by segfaulting on load as the top-level values in `Stdint.Uint128` and `Stdint.Int128` initialise (see #45). I believe the problem is architecture-specific, just being triggered on Windows. It's impossible to store 128 bit values in the OCaml heap **and** expect them to be 16-byte aligned. Having tried various experiments and concluded that the fallbacks functions (for when compiler support isn't available) are simply too incomplete/buggy, I propose here a halfway house. Values are manipulated as `__int128_t` and `__uint128_t`, but are _stored_ as a struct with two 64-bit members. There's obviously a performance impact - some functions may well be faster manipulating the struct directly, others (division, for example) will still be faster this way. This version at least works!
- The `custom_operations` weren't setting up the `compare_ext` field and also weren't taking advantage of 4.08.0's `fixed_length` field. I'm not sure if changing `fixed_length` now means that the library cannot deserialize older values (@stedolan?)