### PR TITLE
Update custom_operations initialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@
 * Fix conversion from all ints to uint24 and int24 (#41, @rixed)
 * Fix int24 failing to recover from casts (#43, @rixed)
 * Fix sign extensions (#49, @rixed)
-* `Longval` returns `intnat`, previously `long` was used (#53, @dra27)
+* `Long_val` returns `intnat`, previously `long` was used (#53, @dra27)
+* Reduce size of marshalled custom values on 4.08+ (#54, @dra27)
 
 ## New features:
 

--- a/lib/int128_stubs.c
+++ b/lib/int128_stubs.c
@@ -10,6 +10,7 @@
 #include <caml/intext.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/version.h>
 
 #include "uint128.h"
 #include "int128.h"
@@ -129,13 +130,21 @@ int128_deserialize(void *dst)
   return 16;
 }
 
+#if OCAML_VERSION_MAJOR > 4 || OCAML_VERSION_MAJOR == 4 && OCAML_VERSION_MINOR >= 8
+static const struct custom_fixed_length int128_length = { 16, 16 };
+#endif
+
 struct custom_operations int128_ops = {
   "stdint.int128",
   custom_finalize_default,
   int128_cmp,
   int128_hash,
   int128_serialize,
-  int128_deserialize
+  int128_deserialize,
+  custom_compare_ext_default
+#if OCAML_VERSION_MAJOR > 4 || OCAML_VERSION_MAJOR == 4 && OCAML_VERSION_MINOR >= 8
+  , &int128_length
+#endif
 };
 
 CAMLprim value

--- a/lib/uint128_stubs.c
+++ b/lib/uint128_stubs.c
@@ -10,6 +10,7 @@
 #include <caml/intext.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/version.h>
 
 #include "int8.h"
 #include "int16.h"
@@ -171,13 +172,21 @@ uint128_deserialize(void *dst)
   return 16;
 }
 
+#if OCAML_VERSION_MAJOR > 4 || OCAML_VERSION_MAJOR == 4 && OCAML_VERSION_MINOR >= 8
+static const struct custom_fixed_length uint128_length = { 16, 16 };
+#endif
+
 struct custom_operations uint128_ops = {
   "stdint.uint128",
   custom_finalize_default,
   uint128_cmp,
   uint128_hash,
   uint128_serialize,
-  uint128_deserialize
+  uint128_deserialize,
+  custom_compare_ext_default
+#if OCAML_VERSION_MAJOR > 4 || OCAML_VERSION_MAJOR == 4 && OCAML_VERSION_MINOR >= 8
+  , &uint128_length
+#endif
 };
 
 CAMLprim value

--- a/lib/uint32_stubs.c
+++ b/lib/uint32_stubs.c
@@ -8,6 +8,7 @@
 #include <caml/intext.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/version.h>
 
 #include "uint32.h"
 
@@ -39,13 +40,21 @@ uint32_deserialize(void *dst)
     return 4;
 }
 
+#if OCAML_VERSION_MAJOR > 4 || OCAML_VERSION_MAJOR == 4 && OCAML_VERSION_MINOR >= 8
+static const struct custom_fixed_length uint32_length = { 4, 4 };
+#endif
+
 struct custom_operations uint32_ops = {
     "uint.uint32",
     custom_finalize_default,
     uint32_cmp,
     uint32_hash,
     uint32_serialize,
-    uint32_deserialize
+    uint32_deserialize,
+    custom_compare_ext_default
+#if OCAML_VERSION_MAJOR > 4 || OCAML_VERSION_MAJOR == 4 && OCAML_VERSION_MINOR >= 8
+  , &uint32_length
+#endif
 };
 
 CAMLprim value

--- a/lib/uint64_stubs.c
+++ b/lib/uint64_stubs.c
@@ -8,6 +8,7 @@
 #include <caml/intext.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/version.h>
 
 #include "uint64.h"
 
@@ -39,13 +40,21 @@ uint64_deserialize(void *dst)
     return 8;
 }
 
+#if OCAML_VERSION_MAJOR > 4 || OCAML_VERSION_MAJOR == 4 && OCAML_VERSION_MINOR >= 8
+static const struct custom_fixed_length uint64_length = { 8, 8 };
+#endif
+
 struct custom_operations uint64_ops = {
     "uint.uint64",
     custom_finalize_default,
     uint64_cmp,
     uint64_hash,
     uint64_serialize,
-    uint64_deserialize
+    uint64_deserialize,
+    custom_compare_ext_default
+#if OCAML_VERSION_MAJOR > 4 || OCAML_VERSION_MAJOR == 4 && OCAML_VERSION_MINOR >= 8
+  , &uint64_length
+#endif
 };
 
 CAMLprim value


### PR DESCRIPTION
Split off from #50. `compare_ext` (added in 3.12.1) now initialised with the default function (this would have been initialised to `NULL` before, which is compatible). However, it allows `fixed_length` to be specified for 4.08+. I have now checked and this is a compatible change. This reduces the storage overhead of marshalled values by 12 bytes per value.