### PR TITLE
Fix lognot tests for Int40, Int48, Int56, and Int128

### DIFF
--- a/lib/int40_stubs.c
+++ b/lib/int40_stubs.c
@@ -30,6 +30,13 @@ int40_div(value v1, value v2)
 }
 
 CAMLprim value
+int40_xor(value v1, value v2)
+{
+  CAMLparam2(v1, v2);
+  CAMLreturn (copy_int40((Int64_val(v1) ^ Int64_val(v2)) & mask));
+}
+
+CAMLprim value
 int40_shift_right(value v1, value v2)
 {
   CAMLparam2(v1, v2);

--- a/lib/int48_stubs.c
+++ b/lib/int48_stubs.c
@@ -30,6 +30,13 @@ int48_div(value v1, value v2)
 }
 
 CAMLprim value
+int48_xor(value v1, value v2)
+{
+  CAMLparam2(v1, v2);
+  CAMLreturn (copy_int48((Int64_val(v1) ^ Int64_val(v2)) & mask));
+}
+
+CAMLprim value
 int48_shift_right(value v1, value v2)
 {
   CAMLparam2(v1, v2);

--- a/lib/int56_stubs.c
+++ b/lib/int56_stubs.c
@@ -30,6 +30,13 @@ int56_div(value v1, value v2)
 }
 
 CAMLprim value
+int56_xor(value v1, value v2)
+{
+  CAMLparam2(v1, v2);
+  CAMLreturn (copy_int56((Int64_val(v1) ^ Int64_val(v2)) & mask));
+}
+
+CAMLprim value
 int56_shift_right(value v1, value v2)
 {
   CAMLparam2(v1, v2);

--- a/lib/stdint.ml
+++ b/lib/stdint.ml
@@ -434,7 +434,7 @@ module Int40 = struct
 
     external mul : int40 -> int40 -> int40 = "int40_mul"
     external div : int40 -> int40 -> int40 = "int40_div"
-    external logxor : int40 -> int40 -> int40 = "uint40_xor"
+    external logxor : int40 -> int40 -> int40 = "int40_xor"
     external shift_right : int40 -> int -> int40 = "int40_shift_right"
     external shift_right_logical : int40 -> int -> int40 = "uint40_shift_right"
 
@@ -485,9 +485,10 @@ module Int40 = struct
     external max_int_fun : unit -> int40 = "int40_max_int"
     external min_int_fun : unit -> int40 = "int40_min_int"
     let one = of_int 1
+    let minus_one = of_int (-1)
     let max_int = max_int_fun ()
     let min_int = min_int_fun ()
-    let lognot = logxor max_int
+    let lognot = logxor minus_one
     let compare = Stdint_stdlib_.compare
     let divmod  = (fun x y -> div x y, rem x y)
   end
@@ -518,7 +519,7 @@ module Int48 = struct
 
     external mul : int48 -> int48 -> int48 = "int48_mul"
     external div : int48 -> int48 -> int48 = "int48_div"
-    external logxor : int48 -> int48 -> int48 = "uint48_xor"
+    external logxor : int48 -> int48 -> int48 = "int48_xor"
     external shift_right : int48 -> int -> int48 = "int48_shift_right"
     external shift_right_logical : int48 -> int -> int48 = "uint48_shift_right"
 
@@ -569,9 +570,10 @@ module Int48 = struct
     external max_int_fun : unit -> int48 = "int48_max_int"
     external min_int_fun : unit -> int48 = "int48_min_int"
     let one = of_int 1
+    let minus_one = of_int (-1)
     let max_int = max_int_fun ()
     let min_int = min_int_fun ()
-    let lognot = logxor max_int
+    let lognot = logxor minus_one
     let compare = Stdint_stdlib_.compare
     let divmod  = (fun x y -> div x y, rem x y)
   end
@@ -602,7 +604,7 @@ module Int56 = struct
 
     external mul : int56 -> int56 -> int56 = "int56_mul"
     external div : int56 -> int56 -> int56 = "int56_div"
-    external logxor : int56 -> int56 -> int56 = "uint56_xor"
+    external logxor : int56 -> int56 -> int56 = "int56_xor"
     external shift_right : int56 -> int -> int56 = "int56_shift_right"
     external shift_right_logical : int56 -> int -> int56 = "uint56_shift_right"
 
@@ -653,9 +655,10 @@ module Int56 = struct
     external max_int_fun : unit -> int56 = "int56_max_int"
     external min_int_fun : unit -> int56 = "int56_min_int"
     let one = of_int 1
+    let minus_one = of_int (-1)
     let max_int = max_int_fun ()
     let min_int = min_int_fun ()
-    let lognot = logxor max_int
+    let lognot = logxor minus_one
     let compare = Stdint_stdlib_.compare
     let divmod  = (fun x y -> div x y, rem x y)
   end
@@ -742,11 +745,12 @@ module Int128 = struct
 
     let zero = of_int 0
     let one = of_int 1
+    let minus_one = of_int (-1)
     let succ = add one
     let pred x = sub x one
     let max_int = max_int_fun ()
     let min_int = min_int_fun ()
-    let lognot = logxor max_int
+    let lognot = logxor minus_one
     let compare = Stdint_stdlib_.compare
     let divmod  = (fun x y -> div x y, rem x y)
 


### PR DESCRIPTION
This is a partial fix for https://github.com/andrenth/ocaml-stdint/issues/59.  I first tried defining and using `minus_one` in the `lognot` definitions for the affected types.  However, that failed in a different way.  The result of `lognot` applied to zero was one, not minus one.  I gave the signed types their own XOR functions and that fixed the issue, so apparently `logxor` is currently broken for those 4 types if one of the arguments is negative.