### PR TITLE
Fix limit pos_int range to never exceed maxi

### DIFF
--- a/tests/stdint_test.ml
+++ b/tests/stdint_test.ml
@@ -27,7 +27,7 @@ struct
   let () = assert (mini < maxi)
 
   let in_range = QCheck.int_range mini maxi
-  let pos_int = QCheck.map_same_type abs in_range
+  let pos_int = QCheck.int_range 0 maxi
   let in_range_float =
     QCheck.float_range (float_of_int mini) (float_of_int maxi)
 end


### PR DESCRIPTION
Tests using pos_int could sometimes be passed a negative integer because
abs mini > maxi. This is now fixed by just defining it as a normal bound
with maxi as its upper bound.

Interestingly, I only ran into this counterexample with qcheck 0.17 and
never with qcheck 0.16.